### PR TITLE
feat: add subscription status display to LINE bot subscription list

### DIFF
--- a/src/api/features/line/webhook/executionFunctionByName.workflow.ts
+++ b/src/api/features/line/webhook/executionFunctionByName.workflow.ts
@@ -104,13 +104,16 @@ const handleGetSubscriptions = async (subscriptions: SubscriptionEntity[]): Prom
     return { message: 'サブスクリプションの登録がありません。' };
   }
 
+  const now = DateUtils.create.now();
+
   return {
     message: `登録済みサブスクリプション（${subscriptions.length}件）
 
 ${subscriptions
   .map(
     (subscription) => `・${subscription.name}
-　・${formatPrice(subscription.price, subscription.currency)}/${getCycleMonths(subscription.cycle)}`,
+　・${formatPrice(subscription.price, subscription.currency)}/${getCycleMonths(subscription.cycle)}
+　・${Subscription.getStatus(subscription)(now)}`,
   )
   .join('\n')}
 


### PR DESCRIPTION
Add subscription status display (Active, Cancelled, Expired) to the LINE bot subscription list response.

## Changes
- Modified `handleGetSubscriptions()` function to include status in response format
- Added status calculation using existing `Subscription.getStatus()` function
- Updated output format to show subscription name, price/cycle, and status

## Output Format
```
・サービス名
　・価格/サイクル
　・ステータス
```

Resolves #19

Generated with [Claude Code](https://claude.ai/code)