### PR TITLE
feat: サブスクリプション一覧にステータス表示を追加

### DIFF
--- a/src/api/features/line/webhook/executionFunctionByName.workflow.ts
+++ b/src/api/features/line/webhook/executionFunctionByName.workflow.ts
@@ -104,13 +104,16 @@ const handleGetSubscriptions = async (subscriptions: SubscriptionEntity[]): Prom
     return { message: 'サブスクリプションの登録がありません。' };
   }
 
+  const now = DateUtils.create.now();
+
   return {
     message: `登録済みサブスクリプション（${subscriptions.length}件）
 
 ${subscriptions
   .map(
     (subscription) => `・${subscription.name}
-　・${formatPrice(subscription.price, subscription.currency)}/${getCycleMonths(subscription.cycle)}`,
+　・${formatPrice(subscription.price, subscription.currency)}/${getCycleMonths(subscription.cycle)}
+　・${getStatusForList(subscription, now)}`,
   )
   .join('\n')}
 
@@ -301,6 +304,21 @@ const aggregatePayments = (payments: (PaymentInfo | null)[]): AggregatedPayments
 // ============================================================================
 // フォーマット関連関数
 // ============================================================================
+
+/**
+ * サブスクリプション一覧用のステータス表示を取得
+ */
+const getStatusForList = (subscription: SubscriptionEntity, now: Date): string => {
+  const status = Subscription.getStatus(subscription)(now);
+  switch (status) {
+    case SubscriptionStatusEnum.Cancelled:
+      return 'Cancelled';
+    case SubscriptionStatusEnum.Expired:
+      return 'Expired';
+    default:
+      return 'Active';
+  }
+};
 
 /**
  * サブスクリプション詳細を整形する


### PR DESCRIPTION
LINE応答でサブスクリプション一覧を取得する際に、各サブスクリプションのステータス（Active/Cancelled/Expired）を表示するように修正。

## 修正内容
- getStatusForList関数を追加（英語ステータス表示用）
- handleGetSubscriptions関数を修正してステータス情報を含む表示に変更
- サブスクリプション一覧で名前・価格・サイクル・ステータスが表示されるように

Fixes #19

Generated with [Claude Code](https://claude.ai/code)