### PR TITLE
chore

### DIFF
--- a/.github/claude-settings.json
+++ b/.github/claude-settings.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "SlashCommand",
+      "Read",
+      "Write",
+      "Edit",
+      "MultiEdit",
+      "Bash",
+      "Glob",
+      "Grep",
+      "WebFetch",
+      "TodoWrite",
+      "WebSearch",
+      "BashOutput",
+      "KillShell",
+      "ExitPlanMode",
+      "NotebookEdit"
+    ]
+  }
+}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,8 +48,7 @@ jobs:
 
             その後、スラッシュコマンドが正常に動作したことを報告してください。
 
-          # Optional: Add claude_args to customize behavior and configuration
+          # Use settings file for configuration instead of claude_args
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowedTools SlashCommand,Read,Write,Edit,Bash,Glob,Grep,WebFetch,TodoWrite'
+          settings: '.github/claude-settings.json'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## 技術スタック
 
-- **フレームワーク**: Next.js with App Router (v15.1.4)
+- **フレームワーク**: Next.js with App Router
 - **APIレイヤー**: Hono（APIルーティング用）
 - **データベース**:
   - Supabase（PostgreSQLデータベースと認証）
@@ -26,7 +26,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **テスト**: Vitest
 - **リンティング/フォーマッティング**: Biome
 - **外部サービス**: LINE Bot SDK、OpenAI API
-- **実行環境要件**: Node.js v20以上、pnpm v10.5.2以上
+- **実行環境要件**: Node.js、pnpm
 
 ## よく使うコマンド
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch Claude Code GitHub Action to use a settings file and generalize versions in CLAUDE.md.
> 
> - **CI/GitHub Actions**:
>   - Switch `/.github/workflows/claude.yml` from `claude_args` to `settings: '.github/claude-settings.json'`.
>   - Add `/.github/claude-settings.json` with allowed tools (`SlashCommand`, `Read`, `Write`, `Edit`, `MultiEdit`, `Bash`, `Glob`, `Grep`, `WebFetch`, `TodoWrite`, `WebSearch`, `BashOutput`, `KillShell`, `ExitPlanMode`, `NotebookEdit`).
> - **Docs**:
>   - Update `CLAUDE.md` to remove specific version pins for Next.js and runtime requirements, keeping them generic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 436e707922e88104b832679ca0c0eda53131e314. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->